### PR TITLE
Adding an alternative way for receiving jwt

### DIFF
--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -288,6 +288,7 @@ const update = async (req, res) => {
         mobile: user.mobile,
         type: user.type,
         college: user.college,
+        token: token,
       },
     });
   } catch (e) {
@@ -346,6 +347,7 @@ const login = async (req, res) => {
 
     res.cookie("token", token).json({
       status: 200,
+      message: "Success. User successfully logged it.",
       data: {
         id: user.id,
         name: user.name,
@@ -353,6 +355,7 @@ const login = async (req, res) => {
         mobile: user.mobile,
         type: user.type,
         college: user.college,
+        token: token,
       },
     });
   } catch (e) {

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -278,7 +278,10 @@ const update = async (req, res) => {
       type: user.type,
     });
 
-    return res.cookie("token", token).json({
+    return res.cookie("token", token, {
+      httpOnly: true,
+      maxAge: 6 * 60 * 60 * 1000,
+    }).json({
       status: 200,
       message: "Success. User updated.",
       data: {
@@ -345,7 +348,10 @@ const login = async (req, res) => {
       type: user.type,
     });
 
-    res.cookie("token", token).json({
+    res.cookie("token", token, {
+      httpOnly: true,
+      maxAge: 6 * 60 * 60 * 1000,
+    }).json({
       status: 200,
       message: "Success. User successfully logged it.",
       data: {

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -7,7 +7,7 @@ const { HTTP_STATUS } = require("../utils/constants");
 module.exports = async (req, res, next) => {
   if (req.url === "/users/login" && req.method === "POST") return next();
 
-  const token;
+  let token;
   const bearer = req.get("Authorization");
   if (bearer) token = bearer;
   else token = req.cookies && req.cookies.token;

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -7,7 +7,10 @@ const { HTTP_STATUS } = require("../utils/constants");
 module.exports = async (req, res, next) => {
   if (req.url === "/users/login" && req.method === "POST") return next();
 
-  const token = req.cookies && req.cookies.token;
+  const token;
+  const bearer = req.get("Authorization");
+  if (bearer) token = bearer;
+  else token = req.cookies && req.cookies.token;
 
   if (!token) return res.status(401).json(HTTP_STATUS[401]);
 


### PR DESCRIPTION
We'll now prefer the token received in the `Authorization` header over the token received through cookies.