### PR TITLE
Using mongoexport instead of mongodump for backup

### DIFF
--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -1,0 +1,30 @@
+const child_process = require("child_process");
+const fs = require("fs");
+const dotenv = require("dotenv");
+dotenv.config();
+
+
+const importCollection = (collectionName) => {
+    return new Promise((resolve, reject) => {
+        let db = process.env.MONGODB_DATABASE || "utsav";
+        if (JSON.parse(fs.readFileSync("../backup/dump/" + collectionName + ".json")).length == 0)
+            return resolve();
+        child_process.exec(`mongoimport --db=${db} --collection=${collectionName}  --jsonArray --file=${collectionName}.json`, {
+            cwd: "../backup/dump"
+        }, (err) => {
+            if (err) {
+                reject(err);
+            }
+            console.log(collectionName + " restored");
+            resolve();
+        });
+    })
+}
+
+const main = async () => {
+    let collections = fs.readdirSync("../backup/dump").filter(file => file.endsWith(".json")).map(file => file.slice(0, -5));
+    await Promise.all(collections.map(collectionName => importCollection(collectionName)));
+    console.log("Done");
+}
+
+main();

--- a/src/middlewares/backupMongo.js
+++ b/src/middlewares/backupMongo.js
@@ -1,4 +1,39 @@
 const child_process = require("child_process");
+const mongoose = require("mongoose");
+
+
+const exportCollection = (collectionName, user) => {
+    return new Promise((resolve, reject) => {
+        let db = process.env.MONGODB_DATABASE || "utsav";
+        child_process.exec(`mongoexport --db=${db} --collection=${collectionName}  --jsonArray --out=${collectionName}.json --pretty`, {
+            cwd: "../backup/dump"
+        }, (err) => {
+            if (user) {
+                if (err) {
+                    reject(err);
+                }
+                resolve();
+            }
+        });
+    })
+}
+
+const updateBackupRepo = async (commit_msg, user) => {
+    return new Promise((resolve, reject) => {
+        child_process.exec(`git add . && git commit -m "${commit_msg}" && git push`, {
+            cwd: "../backup/dump"
+        }, (err) => {
+            if (user) {
+                if (err) {
+                    reject(err);
+                }
+                console.log("Backed up after", commit_msg);
+                resolve();
+            }
+        })
+    })
+}
+
 module.exports = (req, res, next) => {
     res.on("finish", async () => {
         try {
@@ -6,18 +41,11 @@ module.exports = (req, res, next) => {
                 return;
             let { method, url, baseUrl, user } = req;
             let commit_msg = `${method} ${baseUrl}/${url} ${user ? user.email : "(guest)"}`;
-
-            await new Promise((res, rej) => {
-                child_process.exec(`cd ../backup && mongodump && cd dump && git add . && git commit -m "${commit_msg}" && git push`, (err) => {
-                    if (user) {
-                        if (err) {
-                            rej(err);
-                        }
-                        console.log("Backed up after", commit_msg);
-                        res();
-                    }
-                })
-            })
+            let collectionNames = (await mongoose.connection.db.listCollections().toArray()).map(col => col.name);
+            //export all collections as json to backup folder
+            await Promise.all(collectionNames.map(async collection => exportCollection(collection, user)));
+            //commit changes
+            await updateBackupRepo(commit_msg, user);
         } catch (e) {
             console.error("Failed to backup ", e);
         }


### PR DESCRIPTION
Benefits:
* Backup files becomes readable as mongoexport can export as json while mongodump is limited to bson files
* On each update we can exactly see what changed and by who
* Commit size becomes less as git can easily diff between text files but not with binary files
* We can easily make changes on github and make a pull & restore to update the database to the state we want.

Created a restore.js file as well which should be run from the root folder of the backend project
`node ./scripts/restore.js`
